### PR TITLE
Fix revision sti support - 4.8.0

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -64,9 +64,18 @@ module Audited
     # the object has been destroyed, this will be a new record.
     def revision
       clazz = auditable_type.constantize
-      (clazz.find_by_id(auditable_id) || clazz.new).tap do |m|
-        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors).merge(audit_version: version))
-      end
+      attributes = self.class.reconstruct_attributes(ancestors).merge(version: version)
+      inheritance_column = clazz.inheritance_column.to_s
+
+      instance = if clazz.exists?(id: auditable_id)
+                   clazz.find_by_id(auditable_id)
+                 elsif attributes.key?(inheritance_column)
+                   clazz.new(inheritance_column => attributes.delete(inheritance_column))
+                 else
+                   clazz.new
+                 end
+
+      self.class.assign_revision_attributes(instance, attributes)
     end
 
     # Returns a hash of the changed attributes with the new values

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -24,7 +24,7 @@ module Audited
       # * +except+ - Excludes fields from being saved in the audit log.
       #   By default, Audited will audit all but these fields:
       #
-      #     [self.primary_key, inheritance_column, 'lock_version', 'created_at', 'updated_at']
+      #     [self.primary_key, 'lock_version', 'created_at', 'updated_at']
       #   You can add to those by passing one or an array of fields to skip.
       #
       #     class User < ActiveRecord::Base
@@ -380,7 +380,7 @@ module Audited
       end
 
       def default_ignored_attributes
-        [primary_key, inheritance_column] | Audited.ignored_attributes
+        [primary_key] | Audited.ignored_attributes
       end
 
       protected

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -146,6 +146,26 @@ describe Audited::Audit do
       expect(revision.name).to eq(user.name)
       expect(revision).to be_a_new_record
     end
+    
+    context "single-table inheritance" do
+      it "should return the right subclass for existing records" do
+        sti_company = Models::ActiveRecord::Company::STICompany.create
+        revision = sti_company.audits.last.revision
+        expect(revision).to be_a(Models::ActiveRecord::Company::STICompany)
+      end
+
+      it "should return the right subclass for deleted records" do
+        sti_company = Models::ActiveRecord::Company::STICompany.create
+        sti_company.destroy
+        revision = sti_company.audits.last.revision
+
+        if Models::ActiveRecord::Company::STICompany.respond_to?(:attr_accessible)
+          expect(revision).to be_a(Models::ActiveRecord::Company)
+        else
+          expect(revision).to be_a(Models::ActiveRecord::Company::STICompany)
+        end
+      end
+    end
   end
 
   it "should set the version number on create" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -16,6 +16,12 @@ describe Audited::Auditor do
         expect(Models::ActiveRecord::User.non_audited_columns).to include(column)
       end
     end
+    
+    context "single-table inheritance record" do
+      it "should audit type to retrieve object revisions without loosing inheritance information" do
+        expect(Models::ActiveRecord::Company::STICompany.non_audited_columns).not_to include('type')
+      end
+    end
 
     context "should be configurable which conditions are audited" do
       subject { ConditionalCompany.new.send(:auditing_enabled) }


### PR DESCRIPTION
## Details
This PR fixes an issue where the subclass of a record from a single-inheritance table can't be recovered anymore with Audit#revision after the record was deleted.

The reason for this is that the inheritance_column is not audited by default, which means the subclass is impossible to retrieve after a record has been deleted.

My naive solution for this problem is to just track changes to the inheritance_column, and make sure the audited class is instantiated properly when a revision is created.

## Concerns
1. I am not fully aware why the inheritance_column has been ignored so far — this fix is based on the assumption that this was just an oversight. Are there any issues with this? All tests are passing on my machine though.

2. If the inheritance column or the class name have ever been refactored without a migration of the existing audits’ inheritance column, an ActiveRecord::SubclassNotFound will be raised if an audit's revision is retrieved (because we rely on this). Should this be handled more gracefully, with a fall back to the parent class?